### PR TITLE
updatePackets logic updated

### DIFF
--- a/lib/models/PodData/Packet.ts
+++ b/lib/models/PodData/Packet.ts
@@ -23,6 +23,8 @@ export function updatePacket(
         packet.measurements,
         update.measurementUpdates
     );
+
+    return packet;
 }
 
 function updateMeasurements(

--- a/lib/store/podDataStore.ts
+++ b/lib/store/podDataStore.ts
@@ -13,7 +13,7 @@ import { create, StateCreator, StoreApi, UseBoundStore } from "zustand";
 export interface PodDataStore {
     podData: PodData
     initPodData: (podDataAdapter: PodDataAdapter) => void
-    updatePodData: (newPodData: Record<number, PacketUpdate>) => void
+    updatePodData: (packetUpdates: Record<number, PacketUpdate>) => void
 }
 
 export const usePodDataStore = create<PodDataStore>((set, get) => ({
@@ -56,14 +56,14 @@ export const usePodDataStore = create<PodDataStore>((set, get) => ({
     },
 
     /**
-     * Reducer that updates the state based on newPodData.
-     * @param {Record<number, PacketUpdate>} newPodData 
+     * Reducer that updates the state based on packetUpdates.
+     * @param {Record<number, PacketUpdate>} packetUpdates 
      */
-    updatePodData: (newPodData: Record<number, PacketUpdate>) => {
-
+    updatePodData: (packetUpdates: Record<number, PacketUpdate>) => {
+2
         const podData = get().podData;
 
-        for (const update of Object.values(newPodData)) {
+        for (const update of Object.values(packetUpdates)) {
             const packet = getPacket(podData, update.id);
             if (packet) {
                 const boardIndex = podData.packetToBoard[update.id];
@@ -106,7 +106,7 @@ export const usePodDataStore = create<PodDataStore>((set, get) => ({
             ...state,
             podData: {
                 ...state.podData,
-                lastUpdates: newPodData
+                lastUpdates: packetUpdates
             }
         }))
     },


### PR DESCRIPTION
The last change in this repo was switching from Redux to Zustand, but I left pending the function updatePackets in podDataStore, which was not trivial to change.

In this PR, I have incorporated this change. Briefly, this function updates packet information from PodData (like warning values or cycle time). For this task, it has to update the Board that the packet we want to edit is related to and then update the Boards array stored in PodData.